### PR TITLE
Fix garbled terminal display in some cases

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,6 +6,16 @@
   locale_gen:
     name: ja_JP.UTF-8
 
+- name: Check system locale
+  command: localectl status
+  register: _uc_localectl_result
+  check_mode: no
+  changed_when: false
+
+- name: Change system locale
+  command: update-locale LANG=en_US.UTF-8
+  changed_when: "'LANG=en_US.UTF-8' not in _uc_localectl_result.stdout"
+
 - name: Changing hostname
   import_tasks: change_hostname.yml
   when:


### PR DESCRIPTION
I fixed a problem that Japanese characters were garbled on some servers. (e.g. Sakura VPS)

サーバによっては日本語の表示が文字化けする場合があり、その問題への対策を行いました。（さくらVPSなどで発生）